### PR TITLE
feat: ユーザー更新APIの実装

### DIFF
--- a/src/main/kotlin/fleet/tracker/application_service/user/UserService.kt
+++ b/src/main/kotlin/fleet/tracker/application_service/user/UserService.kt
@@ -70,28 +70,19 @@ class UserServiceImpl(val userRepository: UserRepository): UserService {
     override fun updateUser(uid: String, updateUserDTO: UpdateUserDTO): Map<String, String> {
         try {
             val user = userRepository.findByUserOrNull(uid) ?: throw UserNotFoundException("User not found")
-    
+
             val updatedUser = user.copy(
                 userName = updateUserDTO.userName ?: user.userName,
                 fcmTokenId = updateUserDTO.fcmTokenId ?: user.fcmTokenId
             )
-    
+
             val response = mutableMapOf<String, String>()
 
-            if (updateUserDTO.userName != null) {
-                response["user_name"] = updateUserDTO.userName
-            } else {
-                response["user_name"] = user.userName
-            }
+            response["user_name"] = updateUserDTO.userName ?: user.userName
+            response["fcm_token_id"] = updateUserDTO.fcmTokenId ?: user.fcmTokenId
 
-            if (updateUserDTO.fcmTokenId != null) {
-                response["fcm_token_id"] = updateUserDTO.fcmTokenId
-            } else {
-                response["fcm_token_id"] = user.fcmTokenId
-            }
-    
             userRepository.update(updatedUser)
-    
+
             return response
         } catch (e: UserNotFoundException) {
             throw e

--- a/src/main/kotlin/fleet/tracker/controller/user/UserController.kt
+++ b/src/main/kotlin/fleet/tracker/controller/user/UserController.kt
@@ -3,6 +3,7 @@ package fleet.tracker.controller.user
 import fleet.tracker.application_service.user.UserService
 import fleet.tracker.dto.UserDTO
 import fleet.tracker.dto.CreateUserDTO
+import fleet.tracker.dto.UpdateUserDTO
 import fleet.tracker.model.User
 import fleet.tracker.exeption.user.UserNotFoundException
 import org.springframework.http.ResponseEntity
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.dao.DataIntegrityViolationException
 
 @RestController
@@ -47,8 +49,6 @@ class UserController(val userService: UserService) {
         } 
     }
 
-    @RestController
-class UserController(val userService: UserService) {
     @DeleteMapping("/user")
     fun deleteUser(@RequestParam("uid") uid: String): ResponseEntity<Void> {
         return try {
@@ -60,5 +60,31 @@ class UserController(val userService: UserService) {
             ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
         }
     }
-}
+
+    @PutMapping("/user")
+    fun updateUser(@RequestBody updateUserDTO: UpdateUserDTO): ResponseEntity<*> {
+        return try {
+            val updatedFields = mutableMapOf<String, String>()
+
+            if (updateUserDTO.userName != null) {
+                updatedFields["user_name"] = updateUserDTO.userName
+            }
+
+            if (updateUserDTO.fcmTokenId != null) {
+                updatedFields["fcm_token_id"] = updateUserDTO.fcmTokenId
+            }
+
+            if (updatedFields.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Resource not found")
+            }
+
+            userService.updateUser(updateUserDTO.uid!!, updateUserDTO)
+
+            ResponseEntity.ok(updatedFields)
+        } catch (e: UserNotFoundException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found")
+        } catch (e: Exception) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred")
+        }
+    }
 }

--- a/src/main/kotlin/fleet/tracker/controller/user/UserController.kt
+++ b/src/main/kotlin/fleet/tracker/controller/user/UserController.kt
@@ -62,24 +62,9 @@ class UserController(val userService: UserService) {
     }
 
     @PutMapping("/user")
-    fun updateUser(@RequestBody updateUserDTO: UpdateUserDTO): ResponseEntity<*> {
+    fun updateUser(@RequestParam("uid") uid: String, @RequestBody updateUserDTO: UpdateUserDTO): ResponseEntity<*> {
         return try {
-            val updatedFields = mutableMapOf<String, String>()
-
-            if (updateUserDTO.userName != null) {
-                updatedFields["user_name"] = updateUserDTO.userName
-            }
-
-            if (updateUserDTO.fcmTokenId != null) {
-                updatedFields["fcm_token_id"] = updateUserDTO.fcmTokenId
-            }
-
-            if (updatedFields.isEmpty()) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Resource not found")
-            }
-
-            userService.updateUser(updateUserDTO.uid!!, updateUserDTO)
-
+            val updatedFields = userService.updateUser(uid, updateUserDTO)
             ResponseEntity.ok(updatedFields)
         } catch (e: UserNotFoundException) {
             ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found")

--- a/src/main/kotlin/fleet/tracker/dto/UpdateUserDTO.kt
+++ b/src/main/kotlin/fleet/tracker/dto/UpdateUserDTO.kt
@@ -3,8 +3,8 @@ package fleet.tracker.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class UpdateUserDTO(
-    @JsonProperty("uid")
-    val uid: String?,
+    @JsonProperty("uid", required = true)
+    val uid: String,
     @JsonProperty("user_name")
     val userName: String?,
     @JsonProperty("fcm_token_id")

--- a/src/main/kotlin/fleet/tracker/dto/UpdateUserDTO.kt
+++ b/src/main/kotlin/fleet/tracker/dto/UpdateUserDTO.kt
@@ -1,0 +1,12 @@
+package fleet.tracker.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class UpdateUserDTO(
+    @JsonProperty("uid")
+    val uid: String?,
+    @JsonProperty("user_name")
+    val userName: String?,
+    @JsonProperty("fcm_token_id")
+    val fcmTokenId: String?
+)

--- a/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
+++ b/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
@@ -13,6 +13,7 @@ interface UserRepository {
     fun save(user: User): User
     fun isUserExists(uid: String): Boolean
     fun deleteByUserId(uid: String)
+    fun update(user: User): User
 }
 
 @Repository
@@ -66,5 +67,18 @@ class UserRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         val sqlParams = MapSqlParameterSource().addValue("uid", uid)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun update(user: User): User {
+        val sql = """
+            UPDATE "User" SET user_name=:userName, fcm_token_id=:fcmTokenId WHERE uid=:uid
+        """.trimIndent()
+        val sqlParams = MapSqlParameterSource()
+            .addValue("uid", user.uid)
+            .addValue("userName", user.userName)
+            .addValue("fcmTokenId", user.fcmTokenId)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+        return user
     }
 }

--- a/src/test/kotlin/fleet/tracker/controller/user/UpdateUserTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/user/UpdateUserTest.kt
@@ -1,0 +1,103 @@
+package fleet.tracker.controller.user
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import fleet.tracker.dto.UpdateUserDTO
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/user/Insert_User_Test_Data.sql")
+class UserControllerUpdateTests {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should update user successfully`() {
+        val updateUserDTO = UpdateUserDTO(
+            uid = "test_user_1",
+            userName = "updated user",
+            fcmTokenId = "updated_fcm_token"
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateUserDTO)))
+
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().json("""
+                {
+                    "user_name": "${updateUserDTO.userName}",
+                    "fcm_token_id": "${updateUserDTO.fcmTokenId}"
+                }
+            """.trimIndent()))
+    }
+
+    @Test
+    fun `should update user successfully when user_name is not provided`() {
+        val updateUserDTO = UpdateUserDTO(
+            uid = "test_user_1",
+            userName = null,
+            fcmTokenId = "updated_fcm_token"
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateUserDTO)))
+
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().json("""
+                {
+                    "fcm_token_id": "${updateUserDTO.fcmTokenId}"
+                }
+            """.trimIndent()))
+    }
+
+    @Test
+    fun `should update user successfully when fcm_token_id is not provided`() {
+        val updateUserDTO = UpdateUserDTO(
+            uid = "test_user_1",
+            userName = "updated_user_name",
+            fcmTokenId = null
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateUserDTO)))
+
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().json("""
+                {
+                    "user_name": "${updateUserDTO.userName}"
+                }
+            """.trimIndent()))
+    }
+
+    @Test
+    fun `should return 404 when updating non-existing user`() {
+        val updateUserDTO = UpdateUserDTO(
+            uid = "non_existing_user",
+            userName = "updated user",
+            fcmTokenId = "updated_fcm_token"
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateUserDTO)))
+
+        result.andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
+}

--- a/src/test/kotlin/fleet/tracker/controller/user/UpdateUserTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/user/UpdateUserTest.kt
@@ -27,13 +27,15 @@ class UserControllerUpdateTests {
 
     @Test
     fun `should update user successfully`() {
+        val uid = "test_user_1"
         val updateUserDTO = UpdateUserDTO(
-            uid = "test_user_1",
+            uid = uid,
             userName = "updated user",
             fcmTokenId = "updated_fcm_token"
         )
 
         val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .param("uid", uid)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(updateUserDTO)))
 
@@ -48,13 +50,15 @@ class UserControllerUpdateTests {
 
     @Test
     fun `should update user successfully when user_name is not provided`() {
+        val uid = "test_user_1"
         val updateUserDTO = UpdateUserDTO(
-            uid = "test_user_1",
+            uid = uid,
             userName = null,
             fcmTokenId = "updated_fcm_token"
         )
 
         val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .param("uid", uid)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(updateUserDTO)))
 
@@ -68,13 +72,15 @@ class UserControllerUpdateTests {
 
     @Test
     fun `should update user successfully when fcm_token_id is not provided`() {
+        val uid = "test_user_1"
         val updateUserDTO = UpdateUserDTO(
-            uid = "test_user_1",
+            uid = uid,
             userName = "updated_user_name",
             fcmTokenId = null
         )
 
         val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .param("uid", uid)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(updateUserDTO)))
 
@@ -88,13 +94,15 @@ class UserControllerUpdateTests {
 
     @Test
     fun `should return 404 when updating non-existing user`() {
+        val uid = "non_existing_user"
         val updateUserDTO = UpdateUserDTO(
-            uid = "non_existing_user",
+            uid = uid,
             userName = "updated user",
             fcmTokenId = "updated_fcm_token"
         )
 
         val result = mockMvc.perform(MockMvcRequestBuilders.put("/user")
+            .param("uid", uid)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(updateUserDTO)))
 


### PR DESCRIPTION
## 概要
ユーザー更新APIを実装しました。

## 変更点

- APIの仕様に沿うよう、Controller, Service, Repository に追記。
- UpdateUserDTO.kt、UpdateUserTest.kt を作成。

## 確認したこと
- userName と fcmTokenId のうち、新しく入力されたフィールドのみが Responce されることを確認。

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
