### PR TITLE
delayTimeDetailの返り値修正

### DIFF
--- a/src/main/kotlin/fleet/tracker/application_service/delay/DelayService.kt
+++ b/src/main/kotlin/fleet/tracker/application_service/delay/DelayService.kt
@@ -2,11 +2,13 @@ package fleet.tracker.application_service.delay
 
 import fleet.tracker.dto.DelayGetDTO
 import fleet.tracker.dto.DelayPostDTO
+import fleet.tracker.dto.DelayTimeDetail
 import fleet.tracker.exception.database.DatabaseException
 import fleet.tracker.exception.warehoues_area.WarehouseAreaNotFoundException
 import fleet.tracker.exception.warehouse.WarehouseNotFoundException
 import fleet.tracker.infrastructure.delay.DelayRepository
 import fleet.tracker.infrastructure.warehouse.WarehouseRepository
+import fleet.tracker.model.DelayState
 import org.springframework.dao.DataAccessException
 import org.springframework.stereotype.Service
 
@@ -25,7 +27,23 @@ class DelayServiceImpl(val delayRepository: DelayRepository, val warehouseReposi
                 throw WarehouseAreaNotFoundException("WarehouseArea not found")
             }
 
-            return delayRepository.getByWarehouseAreaId(warehouseAreaId)
+            val delays = delayRepository.getByWarehouseAreaId(warehouseAreaId)
+
+            val allStates = DelayState.entries
+
+            return delays.map { delay ->
+                val existingDetails = delay.delayTimeDetail.associateBy { it?.delayState }
+
+                val completeDetails = allStates.map { state ->
+                    existingDetails[state] ?: DelayTimeDetail(state, 0)
+                }
+
+                DelayGetDTO(
+                    warehouseId = delay.warehouseId,
+                    warehouseName = delay.warehouseName,
+                    delayTimeDetail = completeDetails
+                )
+            }
         } catch (e: DataAccessException) {
             throw DatabaseException("Database error", e)
         }

--- a/src/test/kotlin/fleet/tracker/controller/delay/GetDelayTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/delay/GetDelayTest.kt
@@ -40,13 +40,8 @@ class GetDelayTest {
         result.andExpect(content().json("""
             [
               {
-                "warehouse_id": ${warehouse2.warehouseId},
-                "warehouse_name": ${warehouse2.warehouseName},
-                "delay_time_detail": []
-              },
-              {
-                "warehouse_id": ${warehouse1.warehouseId},
-                "warehouse_name": ${warehouse1.warehouseName},
+                "warehouse_id": 1,
+                "warehouse_name": "北海道倉庫1",
                 "delay_time_detail": [
                   {
                     "delay_state": "normal",
@@ -57,8 +52,42 @@ class GetDelayTest {
                     "answer_count": 1
                   },
                   {
+                    "delay_state": "halfHour",
+                    "answer_count": 0
+                  },
+                  {
+                    "delay_state": "anHour",
+                    "answer_count": 0
+                  },
+                  {
                     "delay_state": "impossible",
                     "answer_count": 1
+                  }
+                ]
+              },
+              {
+                "warehouse_id": 2,
+                "warehouse_name": "北海道倉庫2",
+                "delay_time_detail": [
+                  {
+                    "delay_state": "normal",
+                    "answer_count": 0
+                  },
+                  {
+                    "delay_state": "pause",
+                    "answer_count": 0
+                  },
+                  {
+                    "delay_state": "halfHour",
+                    "answer_count": 0
+                  },
+                  {
+                    "delay_state": "anHour",
+                    "answer_count": 0
+                  },
+                  {
+                    "delay_state": "impossible",
+                    "answer_count": 0
                   }
                 ]
               }

--- a/src/test/kotlin/fleet/tracker/controller/warehouse/GetSearchWarehousesTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/warehouse/GetSearchWarehousesTest.kt
@@ -41,7 +41,28 @@ class GetSearchWarehousesTest {
                   "warehouse_area_id": 11,
                   "warehouse_name": "エルフーズ東京工場",
                   "average_delay_state": "normal",
-                  "delay_time_detail": [],
+                  "delay_time_detail": [
+                    {
+                      "delay_state": "normal",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "pause",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "impossible",
+                      "answer_count": 0
+                    }
+                  ],
                   "distance": 3.29
                 },
                 {
@@ -49,7 +70,28 @@ class GetSearchWarehousesTest {
                   "warehouse_area_id": 11,
                   "warehouse_name": "全農城南島営業所",
                   "average_delay_state": "normal",
-                  "delay_time_detail": [],
+                  "delay_time_detail": [
+                    {
+                      "delay_state": "normal",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "pause",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "impossible",
+                      "answer_count": 0
+                    }
+                  ],
                   "distance": 8.58
                 },
                 {
@@ -57,7 +99,28 @@ class GetSearchWarehousesTest {
                   "warehouse_area_id": 11,
                   "warehouse_name": "東京冷蔵城南島物流センター",
                   "average_delay_state": "normal",
-                  "delay_time_detail": [],
+                  "delay_time_detail": [
+                    {
+                      "delay_state": "normal",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "pause",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "impossible",
+                      "answer_count": 0
+                    }
+                  ],
                   "distance": 9.03
                 },
                 {
@@ -65,7 +128,28 @@ class GetSearchWarehousesTest {
                   "warehouse_area_id": 11,
                   "warehouse_name": "横浜水産平和島物流センター",
                   "average_delay_state": "normal",
-                  "delay_time_detail": [],
+                  "delay_time_detail": [
+                    {
+                      "delay_state": "normal",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "pause",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "impossible",
+                      "answer_count": 0
+                    }
+                  ],
                   "distance": 9.17
                 }
               ],
@@ -140,7 +224,28 @@ class GetSearchWarehousesTest {
                   "warehouse_area_id": 1,
                   "warehouse_name": "北海道倉庫2",
                   "average_delay_state": "normal",
-                  "delay_time_detail": [],
+                  "delay_time_detail": [
+                    {
+                      "delay_state": "normal",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "pause",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "impossible",
+                      "answer_count": 0
+                    }
+                  ],
                   "distance": 802.38
                 },
                 {
@@ -156,6 +261,14 @@ class GetSearchWarehousesTest {
                     {
                       "delay_state": "pause",
                       "answer_count": 1
+                    },
+                    {
+                      "delay_state": "halfHour",
+                      "answer_count": 0
+                    },
+                    {
+                      "delay_state": "anHour",
+                      "answer_count": 0
                     },
                     {
                       "delay_state": "impossible",


### PR DESCRIPTION
## 概要
DelayTimeDetailにおいて、取得した遅延Statusのいずれにも該当しないとき、answerCount: 0で当該Statusを返すように修正

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- DelayService及びWarehouseServiceを修正

## 確認したこと
- テストが正常に通ること
- ローカル環境上での動作確認

## リリース時に確認すること
- 正常に遅延情報を返すかどうか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced delay management with new delay states and detailed delay time information in the fleet tracker application.
- **Bug Fixes**
	- Improved accuracy of warehouse search results by incorporating detailed delay states.
- **Tests**
	- Updated test data for warehouse delay details and delay states to ensure consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->