### PR TITLE
fix: Comment を登録した User を削除できない問題を修正

### DIFF
--- a/src/main/kotlin/fleet/tracker/infrastructure/comment/CommentRepository.kt
+++ b/src/main/kotlin/fleet/tracker/infrastructure/comment/CommentRepository.kt
@@ -58,4 +58,24 @@ class CommentRepository(private val namedParameterJdbcTemplate: NamedParameterJd
         val sqlParams = MapSqlParameterSource().addValue("commentId", commentId)
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }
+
+    fun isCommentExistsByUid(uid: String): Boolean {
+        val sql = """
+            SELECT EXISTS(SELECT 1 FROM "Comment" WHERE uid = :uid)
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource().addValue("uid", uid)
+
+        return namedParameterJdbcTemplate.queryForObject(sql, sqlParams, Boolean::class.java) ?: false
+    }
+
+    fun deleteAllByUid(uid: String) {
+        val sql = """
+            DELETE FROM "Comment" WHERE uid = :uid
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource().addValue("uid", uid)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
 }

--- a/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
+++ b/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
@@ -65,13 +65,13 @@ class UserRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
             commentRepository.deleteAllByUid(uid)
         }
         
-        val deleteUserSql = """
+        val sql = """
             DELETE FROM "User" WHERE uid=:uid
         """.trimIndent()
         
         val sqlParams = MapSqlParameterSource().addValue("uid", uid)
     
-        namedParameterJdbcTemplate.update(deleteUserSql, sqlParams)
+        namedParameterJdbcTemplate.update(sql, sqlParams)
     }
     
     

--- a/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
+++ b/src/main/kotlin/fleet/tracker/infrastructure/user/UserRepository.kt
@@ -59,15 +59,21 @@ class UserRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         return namedParameterJdbcTemplate.queryForObject(sql, sqlParams, Boolean::class.java) ?: false
     }
 
-
     override fun deleteByUserId(uid: String) {
-        val sql = """
+        val deleteCommentsSql = """
+            DELETE FROM "Comment" WHERE uid=:uid
+        """.trimIndent()
+        val deleteUserSql = """
             DELETE FROM "User" WHERE uid=:uid
         """.trimIndent()
+    
         val sqlParams = MapSqlParameterSource().addValue("uid", uid)
 
-        namedParameterJdbcTemplate.update(sql, sqlParams)
+        namedParameterJdbcTemplate.update(deleteCommentsSql, sqlParams)
+
+        namedParameterJdbcTemplate.update(deleteUserSql, sqlParams)
     }
+    
 
     override fun update(user: User): User {
         val sql = """

--- a/src/test/kotlin/fleet/tracker/controller/user/DeleteUserTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/user/DeleteUserTest.kt
@@ -32,6 +32,16 @@ class DeleteUserTests {
     }
 
     @Test
+    fun `should delete user without comments successfully`() {
+        val validUid = "test_user_without_comment"
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.delete("/user")
+            .param("uid", validUid))
+
+        result.andExpect(MockMvcResultMatchers.status().isNoContent)
+    }
+
+    @Test
     fun `should return 404 when user is not found`() {
         val invalidUid = "non_existing_user"
 

--- a/src/test/kotlin/fleet/tracker/controller/user/DeleteUserTest.kt
+++ b/src/test/kotlin/fleet/tracker/controller/user/DeleteUserTest.kt
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 @AutoConfigureMockMvc
 @Transactional
 @Sql("/user/Insert_User_Test_Data.sql")
+@Sql("/comment/Insert_Comment_Test_Data.sql")
 class DeleteUserTests {
 
     @Autowired

--- a/src/test/resources/user/Insert_User_Test_Data.sql
+++ b/src/test/resources/user/Insert_User_Test_Data.sql
@@ -1,1 +1,2 @@
 INSERT INTO "User" (uid, user_name, fcm_token_id, created_at, updated_at) values ('test_user_1', 'test_user_1', 'test_user_1', '2021-01-01 00:00:00', '2021-01-01 00:00:00');
+INSERT INTO "User" (uid, user_name, fcm_token_id, created_at, updated_at) values ('test_user_without_comment', 'test_user_without_comment', 'test_user_without_comment', '2023-01-01 00:00:00', '2023-01-01 00:00:00');


### PR DESCRIPTION
## 概要
Comment を登録した User を削除できない問題を修正。

## 変更点

- UserRepository を修正。
- DeleteUserTest.kt に追記。

## 確認したこと
- Comment を登録した User を削除する際、その User が登録した Comment を先に削除することを確認。

## リリース時に確認すること
- リリース作業時に確認することを記載してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved clarity and modularity in user deletion by splitting the deletion process into two distinct operations: one for comments and another for users.

- **New Features**
  - Added functions to check the existence of comments by user ID and to delete all comments by user ID.

- **Tests**
  - Augmented test data setup to include comments in user deletion tests.
  - Extended test data to cover users without comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->