### PR TITLE
AverageDelayStateの計算処理を修正

### DIFF
--- a/src/main/kotlin/fleet/tracker/application_service/warehouse/WarehouseService.kt
+++ b/src/main/kotlin/fleet/tracker/application_service/warehouse/WarehouseService.kt
@@ -261,19 +261,17 @@ data class WarehouseAreaDistance(val warehouseAreaId: Int, val distance: Double)
 // - 遅延情報がない場合は1を設定
 // - 入庫不可が3件以上の場合は入庫不可を返す
 fun List<DelayTimeDetail?>.calculateAverageDelayState(): Int {
-    return if (this.isEmpty()) {
-        1
-    } else {
-        if (this.filterNotNull().count { it.delayState == DelayState.Impossible } >= 3) {
-            return DelayState.Impossible.getWeight()
-        }
-
-        val totalCount = this.filterNotNull().sumOf { it.answerCount }
-        if (totalCount == 0) return 1
-
-        val totalWeight = this.filterNotNull().sumOf { it.delayState.getWeight() * it.answerCount }
-        val average = (totalWeight.toDouble() / totalCount.toDouble()).roundToInt()
-
-        return average
+    if (this.isEmpty()) {
+        return DelayState.Normal.getWeight()
     }
+
+    if (this.filterNotNull().count { it.delayState == DelayState.Impossible } >= 3) {
+        return DelayState.Impossible.getWeight()
+    }
+
+    val totalCount = this.filterNotNull().sumOf { it.answerCount }
+    if (totalCount == 0) return DelayState.Normal.getWeight()
+
+    val totalWeight = this.filterNotNull().sumOf { it.delayState.getWeight() * it.answerCount }
+    return (totalWeight.toDouble() / totalCount.toDouble()).roundToInt()
 }

--- a/src/main/kotlin/fleet/tracker/infrastructure/warehouse/WarehouseRepository.kt
+++ b/src/main/kotlin/fleet/tracker/infrastructure/warehouse/WarehouseRepository.kt
@@ -96,7 +96,7 @@ class WarehouseRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbc
                     "Warehouse" w
                 LEFT JOIN
                     "DelayInformation" d ON w.warehouse_id = d.warehouse_id
-                    AND d.created_at >= NOW() - INTERVAL '24 HOURS'
+                    AND d.created_at >= NOW() - INTERVAL '12 HOURS'
                 WHERE
                     w.warehouse_area_id = :warehouseAreaId
                 GROUP BY


### PR DESCRIPTION
## 概要
average_delay_state計算処理修正

## 変更点

- 遅延情報取得範囲を24時間から12時間に
- 入庫不可が3件以上の場合は平均値に関わらずstatusを入庫不可にする

## 確認したこと
-  テストが通ること

## リリース時に確認すること
- リリース作業時に確認することを記載してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of extreme delay cases in delivery calculations.
  
- **Performance Improvements**
	- Enhanced database query efficiency by reducing the interval for delay state calculations from 24 hours to 12 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->